### PR TITLE
Added Modified to SubscriptionLine

### DIFF
--- a/src/ExactOnline.Client.Models/Subscription/SubscriptionLine.cs
+++ b/src/ExactOnline.Client.Models/Subscription/SubscriptionLine.cs
@@ -39,6 +39,9 @@ namespace ExactOnline.Client.Models.Subscription
         /// <summary>Description of LineType</summary>
         [SDKFieldType(FieldType.ReadOnly)]
         public string LineTypeDescription { get; set; }
+        /// <summary>Last modified date</summary>
+        [SDKFieldType(FieldType.ReadOnly)]
+        public DateTime Modified { get; set; }		
         /// <summary>Net price in the currency of the transaction</summary>
         public double NetPrice { get; set; }
         /// <summary>Remarks</summary>


### PR DESCRIPTION
I'm using the exact package for subscription lines and as we have 12k of them I want to use the modified date to filter on. This property is missing, so I added it.

See the documentation, it supports it.
https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=SubscriptionSubscriptionLines