### PR TITLE
Added PurchaseOrders support canUpdate

### DIFF
--- a/src/ExactOnline.Client.Models/PurchaseOrder/PurchaseOrder.cs
+++ b/src/ExactOnline.Client.Models/PurchaseOrder/PurchaseOrder.cs
@@ -1,6 +1,6 @@
 namespace ExactOnline.Client.Models.PurchaseOrder;
 
-[SupportedActionsSDK(true, true, false, true)]
+[SupportedActionsSDK(true, true, true, true)]
 [DataServiceKey("PurchaseOrderID")]
 public class PurchaseOrder
 {


### PR DESCRIPTION
This pull request makes a minor update to the `PurchaseOrder` model. The change enables support for the "CanUpdate" action in the `PurchaseOrder` entity, according to the [current documentation](https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=PurchaseOrderPurchaseOrders).